### PR TITLE
Smoothen location movement with Kalman filter

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActions.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActions.java
@@ -120,6 +120,7 @@ public class MapActions implements NavigatorListener, MapHandlerListener {
             @Override public void onClick(View v) {
                 navSettingsVP.setVisibility(View.INVISIBLE);
                 sideBarVP.setVisibility(View.VISIBLE);
+                ((MapActivity)activity).ensureLocationListener(true);
             }
         });
         initTravelModeSetting();

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
@@ -124,6 +124,10 @@ public class MapActivity extends Activity implements LocationListener {
       try
       {
         if (Variable.getVariable().isSmoothON()) {
+          locationManager.removeUpdates(this);
+          kalmanLocationManager.requestLocationUpdates(UseProvider.GPS_AND_NET, FILTER_TIME, GPS_TIME, NET_TIME, this, false);
+          logUser("LocationProvider: " + kalmanLocationManager.KALMAN_PROVIDER);
+        } else {
           Criteria criteria = new Criteria();
           criteria.setAccuracy(Criteria.ACCURACY_FINE);
           String provider = locationManager.getBestProvider(criteria, true);
@@ -142,10 +146,6 @@ public class MapActivity extends Activity implements LocationListener {
           lastProvider = provider;
           locationManager.requestLocationUpdates(provider, 3000, 5, this);
           logUser("LocationProvider: " + provider);
-        } else {
-          locationManager.removeUpdates(this);
-          kalmanLocationManager.requestLocationUpdates(UseProvider.GPS_AND_NET, FILTER_TIME, GPS_TIME, NET_TIME, this, false);
-          logUser("LocationProvider: " + kalmanLocationManager.KALMAN_PROVIDER);
         }
         locationListenerStatus = PermissionStatus.Enabled;
       }
@@ -240,9 +240,11 @@ public class MapActivity extends Activity implements LocationListener {
 
     @Override protected void onStop() {
         super.onStop();
-        // Remove location updates
-        locationManager.removeUpdates(this);
-        kalmanLocationManager.removeUpdates(this);
+        // Remove location updates is not needed for tracking
+        if (!Tracking.getTracking(getApplicationContext()).isTracking()) {
+          locationManager.removeUpdates(this);
+          kalmanLocationManager.removeUpdates(this);
+        }
         if (mCurrentLocation != null) {
             GeoPoint geoPoint = mapView.map().getMapPosition().getGeoPoint();
             Variable.getVariable().setLastLocation(geoPoint);

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
@@ -125,7 +125,7 @@ public class MapActivity extends Activity implements LocationListener {
       {
         if (Variable.getVariable().isSmoothON()) {
           locationManager.removeUpdates(this);
-          kalmanLocationManager.requestLocationUpdates(UseProvider.GPS_AND_NET, FILTER_TIME, GPS_TIME, NET_TIME, this, false);
+          kalmanLocationManager.requestLocationUpdates(UseProvider.GPS, FILTER_TIME, GPS_TIME, NET_TIME, this, false);
           logUser("LocationProvider: " + kalmanLocationManager.KALMAN_PROVIDER);
         } else {
           Criteria criteria = new Criteria();

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
@@ -25,10 +25,14 @@ import com.junjunguo.pocketmaps.util.SetStatusBarColor;
 import com.junjunguo.pocketmaps.util.Variable;
 import com.junjunguo.pocketmaps.navigator.NaviEngine;
 
+import com.villoren.android.kalmanlocationmanager.lib.KalmanLocationManager;
+
 import java.io.File;
 
 import org.oscim.android.MapView;
 import org.oscim.core.GeoPoint;
+
+import static com.villoren.android.kalmanlocationmanager.lib.KalmanLocationManager.UseProvider;
 
 /**
  * This file is part of PocketMaps
@@ -42,14 +46,31 @@ public class MapActivity extends Activity implements LocationListener {
     private Location mLastLocation;
     private MapActions mapActions;
     private LocationManager locationManager;
+    private KalmanLocationManager kalmanLocationManager;
     private PermissionStatus locationListenerStatus = PermissionStatus.Unknown;
     private String lastProvider;
+    /**
+     * Request location updates with the highest possible frequency on gps.
+     * Typically, this means one update per second for gps.
+     */
+    private static final long GPS_TIME = 1000;
+    /**
+     * For the network provider, which gives locations with less accuracy (less reliable),
+     * request updates every 5 seconds.
+     */
+    private static final long NET_TIME = 5000;
+    /**
+     * For the filter-time argument we use a "real" value: the predictions are triggered by a timer.
+     * Lets say we want ~25 updates (estimates) per second = update each 40 millis (to make the movement fluent).
+     */
+    private static final long FILTER_TIME = 40;
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lastProvider = null;
         setContentView(R.layout.activity_map);
         locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        kalmanLocationManager = new KalmanLocationManager(this);
         Variable.getVariable().setContext(getApplicationContext());
         Variable.getVariable().setZoomLevels(22, 1);
         mapView = new MapView(this);
@@ -102,28 +123,30 @@ public class MapActivity extends Activity implements LocationListener {
       }
       try
       {
-        Criteria criteria = new Criteria();
-        criteria.setAccuracy(Criteria.ACCURACY_FINE);
-        String provider = locationManager.getBestProvider(criteria, true);
-        if (provider==null)
-        {
-          lastProvider = null;
-          locationManager.removeUpdates(this);
-          logUser("LocationProvider is off!");
-          return;
-        }
-        else if (provider.equals(lastProvider))
-        {
-          if (showMsgEverytime)
-          {
-            logUser("LocationProvider: " + provider);
+        if (Variable.getVariable().isSmoothON()) {
+          Criteria criteria = new Criteria();
+          criteria.setAccuracy(Criteria.ACCURACY_FINE);
+          String provider = locationManager.getBestProvider(criteria, true);
+          if (provider == null) {
+            lastProvider = null;
+            locationManager.removeUpdates(this);
+            logUser("LocationProvider is off!");
+            return;
+          } else if (provider.equals(lastProvider)) {
+            if (showMsgEverytime) {
+              logUser("LocationProvider: " + provider);
+            }
+            return;
           }
-          return;
+          locationManager.removeUpdates(this);
+          lastProvider = provider;
+          locationManager.requestLocationUpdates(provider, 3000, 5, this);
+          logUser("LocationProvider: " + provider);
+        } else {
+          locationManager.removeUpdates(this);
+          kalmanLocationManager.requestLocationUpdates(UseProvider.GPS_AND_NET, FILTER_TIME, GPS_TIME, NET_TIME, this, false);
+          logUser("LocationProvider: " + kalmanLocationManager.KALMAN_PROVIDER);
         }
-        locationManager.removeUpdates(this);
-        lastProvider = provider;
-        locationManager.requestLocationUpdates(provider, 3000, 5, this);
-        logUser("LocationProvider: " + provider);
         locationListenerStatus = PermissionStatus.Enabled;
       }
       catch (SecurityException ex)
@@ -150,7 +173,12 @@ public class MapActivity extends Activity implements LocationListener {
      * check if GPS enabled and if not send user to the GSP settings
      */
     private void checkGpsAvailability() {
-        boolean enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        boolean enabled = false;
+        if (Variable.getVariable().isSmoothON()) {
+          enabled = kalmanLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER, this);
+        } else {
+          enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        }
         if (!enabled) {
             Dialog.showGpsSelector(this);
         }
@@ -212,6 +240,9 @@ public class MapActivity extends Activity implements LocationListener {
 
     @Override protected void onStop() {
         super.onStop();
+        // Remove location updates
+        locationManager.removeUpdates(this);
+        kalmanLocationManager.removeUpdates(this);
         if (mCurrentLocation != null) {
             GeoPoint geoPoint = mapView.map().getMapPosition().getGeoPoint();
             Variable.getVariable().setLastLocation(geoPoint);
@@ -223,6 +254,7 @@ public class MapActivity extends Activity implements LocationListener {
     @Override protected void onDestroy() {
         super.onDestroy();
         locationManager.removeUpdates(this);
+        kalmanLocationManager.removeUpdates(this);
         lastProvider = null;
         mapView.onDestroy();
         if (MapHandler.getMapHandler().getHopper() != null) MapHandler.getMapHandler().getHopper().close();
@@ -246,7 +278,12 @@ public class MapActivity extends Activity implements LocationListener {
       if (mLastLocation != null) { return; }
       try
       {
-        Location lonet = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+        Location lonet = null;
+        if (Variable.getVariable().isSmoothON()) {
+          lonet = kalmanLocationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER, this);
+        } else {
+          lonet = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+        }
         if (lonet != null) { mLastLocation = lonet; return; }
       }
       catch (SecurityException|IllegalArgumentException e)
@@ -255,7 +292,12 @@ public class MapActivity extends Activity implements LocationListener {
       }
       try
       {
-        Location logps = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+        Location logps = null;
+        if (Variable.getVariable().isSmoothON()) {
+          logps = kalmanLocationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER, this);
+        } else {
+          logps = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+        }
         if (logps != null) { mLastLocation = logps; return; }
       }
       catch (SecurityException|IllegalArgumentException e)

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/fragments/AppSettings.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/fragments/AppSettings.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 import com.junjunguo.pocketmaps.R;
 import com.junjunguo.pocketmaps.activities.MainActivity;
 import com.junjunguo.pocketmaps.activities.Analytics;
+import com.junjunguo.pocketmaps.activities.MapActivity;
 import com.junjunguo.pocketmaps.map.Tracking;
 import com.junjunguo.pocketmaps.util.UnitCalculator;
 import com.junjunguo.pocketmaps.util.Variable;
@@ -114,6 +115,7 @@ public class AppSettings {
         cb_smooth.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 Variable.getVariable().setSmoothON(isChecked);
+                ((MapActivity)activity).ensureLocationListener(false);
             }
         });
         if (!Variable.getVariable().isDirectionsON())

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/fragments/AppSettings.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/fragments/AppSettings.java
@@ -82,18 +82,23 @@ public class AppSettings {
         CheckBox cb = (CheckBox) activity.findViewById(R.id.app_settings_directions_cb);
         final CheckBox cb_voice = (CheckBox) activity.findViewById(R.id.app_settings_voice);
         final CheckBox cb_light = (CheckBox) activity.findViewById(R.id.app_settings_light);
+        final CheckBox cb_smooth = (CheckBox) activity.findViewById(R.id.app_settings_smooth);
         final TextView txt_voice = (TextView) activity.findViewById(R.id.txt_voice);
         final TextView txt_light = (TextView) activity.findViewById(R.id.txt_light);
+        final TextView txt_smooth = (TextView) activity.findViewById(R.id.txt_smooth);
         cb.setChecked(Variable.getVariable().isDirectionsON());
         cb_voice.setChecked(Variable.getVariable().isVoiceON());
         cb_light.setChecked(Variable.getVariable().isLightSensorON());
+        cb_smooth.setChecked(Variable.getVariable().isSmoothON());
         cb.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 Variable.getVariable().setDirectionsON(isChecked);
                 cb_voice.setEnabled(isChecked);
                 cb_light.setEnabled(isChecked);
+                cb_smooth.setEnabled(isChecked);
                 txt_voice.setEnabled(isChecked);
                 txt_light.setEnabled(isChecked);
+                txt_smooth.setEnabled(isChecked);
             }
         });
         cb_voice.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -106,12 +111,19 @@ public class AppSettings {
               Variable.getVariable().setLightSensorON(isChecked);
           }
         });
+        cb_smooth.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Variable.getVariable().setSmoothON(isChecked);
+            }
+        });
         if (!Variable.getVariable().isDirectionsON())
         {
           cb_voice.setEnabled(false);
           cb_light.setEnabled(false);
+          cb_smooth.setEnabled(false);
           txt_voice.setEnabled(false);
           txt_light.setEnabled(false);
+          txt_smooth.setEnabled(false);
         }
     }
     

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/util/Variable.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/util/Variable.java
@@ -138,6 +138,7 @@ public class Variable {
 
     private boolean lightSensorON;
     private boolean voiceON;
+    private boolean smoothON;
 
     /**
      * application context
@@ -162,6 +163,7 @@ public class Variable {
         this.directionsON = true;
         this.voiceON = true;
         this.lightSensorON = true;
+        this.smoothON = false;
         this.mapDirectory = "pocketmaps/maps/";
         this.dlDirectory = "pocketmaps/downloads/";
         this.trackingDirectory = "pocketmaps/tracking/";
@@ -251,6 +253,16 @@ public class Variable {
     public void setLightSensorON(boolean lightSensorON)
     {
       this.lightSensorON = lightSensorON;
+    }
+
+    public boolean isSmoothON()
+    {
+        return smoothON;
+    }
+
+    public void setSmoothON(boolean smoothON)
+    {
+        this.smoothON = smoothON;
     }
 
     /**

--- a/PocketMaps/app/src/main/java/com/villoren/android/kalmanlocationmanager/lib/KalmanLocationManager.java
+++ b/PocketMaps/app/src/main/java/com/villoren/android/kalmanlocationmanager/lib/KalmanLocationManager.java
@@ -1,0 +1,191 @@
+/*
+ * KalmanLocationManager
+ *
+ * Copyright (c) 2014 Renato Villone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.villoren.android.kalmanlocationmanager.lib;
+
+import android.content.Context;
+import android.location.LocationListener;
+import android.location.Location;
+import android.util.Log;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides a means of requesting location updates.
+ * <p>
+ * Similar to Android's {@link android.location.LocationManager LocationManager}.
+ */
+public class KalmanLocationManager {
+
+    /**
+     * Specifies which of the native location providers to use, or a combination of them.
+     */
+    public enum UseProvider { GPS, NET, GPS_AND_NET }
+
+    /**
+     * Provider string assigned to predicted Location objects.
+     */
+    public static final String KALMAN_PROVIDER = "kalman";
+
+    /**
+     * Logger tag.
+     */
+    private static final String TAG = KalmanLocationManager.class.getSimpleName();
+
+    /**
+     * The Context the KalmanLocationManager is running in.
+     */
+    private final Context mContext;
+
+    /**
+     * Map that associates provided LocationListeners with created LooperThreads.
+     */
+    private final Map<LocationListener, LooperThread> mListener2Thread;
+
+    /**
+     * Constructor.
+     *
+     * @param context The Context for this KalmanLocationManager.
+     */
+    public KalmanLocationManager(Context context) {
+
+        mContext = context;
+        mListener2Thread = new HashMap<LocationListener, LooperThread>();
+    }
+
+    /**
+     * Register for {@link android.location.Location Location} estimates using the given LocationListener callback.
+     *
+     *
+     * @param useProvider Specifies which of the native location providers to use, or a combination of them.
+     *
+     * @param minTimeFilter Minimum time interval between location estimates, in milliseconds.
+     *                      Indicates the frequency of predictions to be calculated by the filter,
+     *                      thus the frequency of callbacks to be received by the given location listener.
+     *
+     * @param minTimeGpsProvider Minimum time interval between GPS readings, in milliseconds.
+     *                           If {@link UseProvider#NET UseProvider.NET} was set, this value is ignored.
+     *
+     * @param minTimeNetProvider Minimum time interval between Network readings, in milliseconds.
+     *                           If {@link UseProvider#GPS UseProvider.GPS} was set, this value is ignored.
+     *
+     * @param listener A {@link android.location.LocationListener LocationListener} whose
+     *                 {@link android.location.LocationListener#onLocationChanged(android.location.Location) onLocationChanged(Location)}
+     *                 method will be called for each location estimate produced by the filter. It will also receive
+     *                 the status updates from the native providers.
+     *
+     * @param forwardProviderReadings Also forward location readings from the native providers to the given listener.
+     *                                Note that <i>status</i> updates will always be forwarded.
+     *
+     */
+    public void requestLocationUpdates(
+            UseProvider useProvider,
+            long minTimeFilter,
+            long minTimeGpsProvider,
+            long minTimeNetProvider,
+            LocationListener listener,
+            boolean forwardProviderReadings)
+    {
+        // Validate arguments
+        if (useProvider == null)
+            throw new IllegalArgumentException("useProvider can't be null");
+
+        if (listener == null)
+            throw new IllegalArgumentException("listener can't be null");
+
+        if (minTimeFilter < 0) {
+
+            Log.w(TAG, "minTimeFilter < 0. Setting to 0");
+            minTimeFilter = 0;
+        }
+
+        if (minTimeGpsProvider < 0) {
+
+            Log.w(TAG, "minTimeGpsProvider < 0. Setting to 0");
+            minTimeGpsProvider = 0;
+        }
+
+        if (minTimeNetProvider < 0) {
+
+            Log.w(TAG, "minTimeNetProvider < 0. Setting to 0");
+            minTimeNetProvider = 0;
+        }
+
+        // Remove this listener if it is already in use
+        if (mListener2Thread.containsKey(listener)) {
+
+            Log.d(TAG, "Requested location updates with a listener that is already in use. Removing.");
+            removeUpdates(listener);
+        }
+
+        LooperThread looperThread = new LooperThread(
+                mContext, useProvider, minTimeFilter, minTimeGpsProvider, minTimeNetProvider,
+                listener, forwardProviderReadings);
+
+        mListener2Thread.put(listener, looperThread);
+    }
+
+    /**
+     * Removes location estimates for the specified LocationListener.
+     * <p>
+     * Following this call, updates will no longer occur for this listener.
+     *
+     * @param listener Listener object that no longer needs location estimates.
+     */
+    public void removeUpdates(LocationListener listener) {
+
+        LooperThread looperThread = mListener2Thread.remove(listener);
+
+        if (looperThread == null) {
+
+            Log.d(TAG, "Did not remove updates for given LocationListener. Wasn't registered in this instance.");
+            return;
+        }
+
+        looperThread.close();
+    }
+    
+    /**
+     * Added for integration with PocketMaps
+     */
+    public boolean isProviderEnabled (String provider, LocationListener listener) {
+        LooperThread looperThread = mListener2Thread.get(listener);
+        if (looperThread != null) {
+            return looperThread.isProviderEnabled(provider);
+        }
+        return false;
+    } 
+
+    /**
+     * Added for integration with PocketMaps
+     */
+    public Location getLastKnownLocation(String provider, LocationListener listener) {
+        LooperThread looperThread = mListener2Thread.get(listener);
+        if (looperThread != null) {
+            return looperThread.getLastKnownLocation(provider);
+        }
+        return null;
+    }
+}

--- a/PocketMaps/app/src/main/java/com/villoren/android/kalmanlocationmanager/lib/LooperThread.java
+++ b/PocketMaps/app/src/main/java/com/villoren/android/kalmanlocationmanager/lib/LooperThread.java
@@ -1,0 +1,352 @@
+/*
+ * LooperThread
+ *
+ * Copyright (c) 2014 Renato Villone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.villoren.android.kalmanlocationmanager.lib;
+
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.os.SystemClock;
+
+import static com.villoren.android.kalmanlocationmanager.lib.KalmanLocationManager.KALMAN_PROVIDER;
+import static com.villoren.android.kalmanlocationmanager.lib.KalmanLocationManager.UseProvider;
+
+/**
+ * Created by Rena on 28/09/2014.
+ */
+class LooperThread extends Thread {
+    
+    // Static constant
+    private static final int THREAD_PRIORITY = 5;
+
+    private static final double DEG_TO_METER = 111225.0;
+    private static final double METER_TO_DEG = 1.0 / DEG_TO_METER;
+
+    private static final double TIME_STEP = 1.0;
+    private static final double COORDINATE_NOISE = 4.0 * METER_TO_DEG;
+    private static final double ALTITUDE_NOISE = 10.0;
+
+    // Context
+    private final Context mContext;
+    private final Handler mClientHandler;
+    private final LocationManager mLocationManager;
+
+    // Settings
+    private final UseProvider mUseProvider;
+    private final long mMinTimeFilter;
+    private final long mMinTimeGpsProvider;
+    private final long mMinTimeNetProvider;
+    private final LocationListener mClientLocationListener;
+    private final boolean mForwardProviderUpdates;
+
+    // Thread
+    private Looper mLooper;
+    private Handler mOwnHandler;
+    private Location mLastLocation;
+    private boolean mPredicted;
+
+    /**
+     * Three 1-dimension trackers, since the dimensions are independent and can avoid using matrices.
+     */
+    private Tracker1D mLatitudeTracker, mLongitudeTracker, mAltitudeTracker;
+
+    /**
+     *
+     * @param context
+     * @param useProvider
+     * @param minTimeFilter
+     * @param minTimeGpsProvider
+     * @param minTimeNetProvider
+     * @param locationListener
+     * @param forwardProviderUpdates
+     */
+    LooperThread(
+            Context context,
+            UseProvider useProvider,
+            long minTimeFilter,
+            long minTimeGpsProvider,
+            long minTimeNetProvider,
+            LocationListener locationListener,
+            boolean forwardProviderUpdates)
+    {
+        mContext = context;
+        mClientHandler = new Handler();
+        mLocationManager = (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+
+        mUseProvider = useProvider;
+
+        mMinTimeFilter = minTimeFilter;
+        mMinTimeGpsProvider = minTimeGpsProvider;
+        mMinTimeNetProvider = minTimeNetProvider;
+
+        mClientLocationListener = locationListener;
+        mForwardProviderUpdates = forwardProviderUpdates;
+
+        start();
+    }
+
+    @Override
+    public void run() {
+
+        setPriority(THREAD_PRIORITY);
+
+        Looper.prepare();
+        mLooper = Looper.myLooper();
+
+        if (mUseProvider == UseProvider.GPS || mUseProvider == UseProvider.GPS_AND_NET) {
+
+            mLocationManager.requestLocationUpdates(
+                    LocationManager.GPS_PROVIDER, mMinTimeGpsProvider, 0.0f, mOwnLocationListener, mLooper);
+        }
+
+        if (mUseProvider == UseProvider.NET || mUseProvider == UseProvider.GPS_AND_NET) {
+
+            mLocationManager.requestLocationUpdates(
+                    LocationManager.NETWORK_PROVIDER, mMinTimeNetProvider, 0.0f, mOwnLocationListener, mLooper);
+        }
+
+        Looper.loop();
+    }
+
+    public void close() {
+
+        mLocationManager.removeUpdates(mOwnLocationListener);
+        mLooper.quit();
+    }
+
+    private LocationListener mOwnLocationListener = new LocationListener() {
+
+        @Override
+        public void onLocationChanged(final Location location) {
+
+            // Reusable
+            final double accuracy = location.getAccuracy();
+            double position, noise;
+
+            // Latitude
+            position = location.getLatitude();
+            noise = accuracy * METER_TO_DEG;
+
+            if (mLatitudeTracker == null) {
+
+                mLatitudeTracker = new Tracker1D(TIME_STEP, COORDINATE_NOISE);
+                mLatitudeTracker.setState(position, 0.0, noise);
+            }
+
+            if (!mPredicted)
+                mLatitudeTracker.predict(0.0);
+
+            mLatitudeTracker.update(position, noise);
+
+            // Longitude
+            position = location.getLongitude();
+            noise = accuracy * Math.cos(Math.toRadians(location.getLatitude())) * METER_TO_DEG ;
+
+            if (mLongitudeTracker == null) {
+
+                mLongitudeTracker = new Tracker1D(TIME_STEP, COORDINATE_NOISE);
+                mLongitudeTracker.setState(position, 0.0, noise);
+            }
+
+            if (!mPredicted)
+                mLongitudeTracker.predict(0.0);
+
+            mLongitudeTracker.update(position, noise);
+
+            // Altitude
+            if (location.hasAltitude()) {
+
+                position = location.getAltitude();
+                noise = accuracy;
+
+                if (mAltitudeTracker == null) {
+
+                    mAltitudeTracker = new Tracker1D(TIME_STEP, ALTITUDE_NOISE);
+                    mAltitudeTracker.setState(position, 0.0, noise);
+                }
+
+                if (!mPredicted)
+                    mAltitudeTracker.predict(0.0);
+
+                mAltitudeTracker.update(position, noise);
+            }
+
+            // Reset predicted flag
+            mPredicted = false;
+
+            // Forward update if requested
+            if (mForwardProviderUpdates) {
+
+                mClientHandler.post(new Runnable() {
+
+                    @Override
+                    public void run() {
+
+                        mClientLocationListener.onLocationChanged(new Location(location));
+                    }
+                });
+            }
+
+            // Update last location
+            if (location.getProvider().equals(LocationManager.GPS_PROVIDER)
+                    || mLastLocation == null || mLastLocation.getProvider().equals(LocationManager.NETWORK_PROVIDER)) {
+
+                mLastLocation = new Location(location);
+            }
+
+            // Enable filter timer if this is our first measurement
+            if (mOwnHandler == null) {
+
+                mOwnHandler = new Handler(mLooper, mOwnHandlerCallback);
+                mOwnHandler.sendEmptyMessageDelayed(0, mMinTimeFilter);
+            }
+        }
+
+        @Override
+        public void onStatusChanged(String provider, final int status, final Bundle extras) {
+
+            final String finalProvider = provider;
+
+            mClientHandler.post(new Runnable() {
+
+                @Override
+                public void run() {
+
+                    mClientLocationListener.onStatusChanged(finalProvider, status, extras);
+                }
+            });
+        }
+
+        @Override
+        public void onProviderEnabled(String provider) {
+
+            final String finalProvider = provider;
+
+            mClientHandler.post(new Runnable() {
+
+                @Override
+                public void run() {
+
+                    mClientLocationListener.onProviderEnabled(finalProvider);
+                }
+            });
+        }
+
+        @Override
+        public void onProviderDisabled(String provider) {
+
+            final String finalProvider = provider;
+
+            mClientHandler.post(new Runnable() {
+
+                @Override
+                public void run() {
+
+                    mClientLocationListener.onProviderDisabled(finalProvider);
+                }
+            });
+        }
+    };
+
+
+
+    private Handler.Callback mOwnHandlerCallback = new Handler.Callback() {
+
+        @Override
+        public boolean handleMessage(Message msg) {
+
+            // Prepare location
+            final Location location = new Location(KALMAN_PROVIDER);
+
+            // Latitude
+            mLatitudeTracker.predict(0.0);
+            location.setLatitude(mLatitudeTracker.getPosition());
+
+            // Longitude
+            mLongitudeTracker.predict(0.0);
+            location.setLongitude(mLongitudeTracker.getPosition());
+
+            // Altitude
+            if (mLastLocation.hasAltitude()) {
+
+                mAltitudeTracker.predict(0.0);
+                location.setAltitude(mAltitudeTracker.getPosition());
+            }
+
+            // Speed
+            if (mLastLocation.hasSpeed())
+                location.setSpeed(mLastLocation.getSpeed());
+
+            // Bearing
+            if (mLastLocation.hasBearing())
+                location.setBearing(mLastLocation.getBearing());
+
+            // Accuracy (always has)
+            location.setAccuracy((float) (mLatitudeTracker.getAccuracy() * DEG_TO_METER));
+
+            // Set times
+            location.setTime(System.currentTimeMillis());
+
+            if (Build.VERSION.SDK_INT >= 17)
+                location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
+
+            // Post the update in the client (UI) thread
+            mClientHandler.post(new Runnable() {
+
+                @Override
+                public void run() {
+
+                    mClientLocationListener.onLocationChanged(location);
+                }
+            });
+
+            // Enqueue next prediction
+            mOwnHandler.removeMessages(0);
+            mOwnHandler.sendEmptyMessageDelayed(0, mMinTimeFilter);
+            mPredicted = true;
+
+            return true;
+        }
+    };
+
+    /**
+     * Added for integration with PocketMaps
+     */
+    public boolean isProviderEnabled (String provider) {
+        return mLocationManager.isProviderEnabled(provider);
+    } 
+
+    /**
+     * Added for integration with PocketMaps
+     */
+    public Location getLastKnownLocation(String provider) {
+        return mLocationManager.getLastKnownLocation(provider);
+    }
+}

--- a/PocketMaps/app/src/main/java/com/villoren/android/kalmanlocationmanager/lib/Tracker1D.java
+++ b/PocketMaps/app/src/main/java/com/villoren/android/kalmanlocationmanager/lib/Tracker1D.java
@@ -1,0 +1,181 @@
+/*
+ * Tracker1D
+ *
+ * Copyright (c) 2014 Renato Villone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.villoren.android.kalmanlocationmanager.lib;
+
+/**
+ * Kalman filter tracking in one dimension.
+ */
+class Tracker1D {
+
+    // Settings
+
+    /**
+     * Time step
+     */
+    private final double mt, mt2, mt2d2, mt3d2, mt4d4;
+
+    /**
+     * Process noise covariance
+     */
+    private final double mQa, mQb, mQc, mQd;
+
+    /**
+     * Estimated state
+     */
+    private double mXa, mXb;
+
+    /**
+     * Estimated covariance
+     */
+    private double mPa, mPb, mPc, mPd;
+
+    /**
+     * Creates a tracker.
+     *
+     * @param timeStep Delta time between predictions. Usefull to calculate speed.
+     * @param processNoise Standard deviation to calculate noise covariance from.
+     */
+    public Tracker1D(double timeStep, double processNoise) {
+
+        // Lookup time step
+        mt = timeStep;
+        mt2 = mt * mt;
+        mt2d2 = mt2 / 2.0;
+        mt3d2 = mt2 * mt / 2.0;
+        mt4d4 = mt2 * mt2 / 4.0;
+
+        // Process noise covariance
+        double n2 = processNoise * processNoise;
+        mQa = n2 * mt4d4;
+        mQb = n2 * mt3d2;
+        mQc = mQb;
+        mQd = n2 * mt2;
+
+        // Estimated covariance
+        mPa = mQa;
+        mPb = mQb;
+        mPc = mQc;
+        mPd = mQd;
+    }
+
+    /**
+     * Reset the filter to the given state.
+     * <p>
+     * Should be called after creation, unless position and velocity are assumed to be both zero.
+     *
+     * @param position
+     * @param velocity
+     * @param noise
+     */
+    public void setState(double position, double velocity, double noise) {
+
+        // State vector
+        mXa = position;
+        mXb = velocity;
+
+        // Covariance
+        double n2 = noise * noise;
+        mPa = n2 * mt4d4;
+        mPb = n2 * mt3d2;
+        mPc = mPb;
+        mPd = n2 * mt2;
+    }
+
+    /**
+     * Update (correct) with the given measurement.
+     *
+     * @param position
+     * @param noise
+     */
+    public void update(double position, double noise) {
+
+        double r = noise * noise;
+
+        //  y   =  z   -   H  . x
+        double y = position - mXa;
+
+        // S = H.P.H' + R
+        double s = mPa + r;
+        double si = 1.0 / s;
+
+        // K = P.H'.S^(-1)
+        double Ka = mPa * si;
+        double Kb = mPc * si;
+
+        // x = x + K.y
+        mXa = mXa + Ka * y;
+        mXb = mXb + Kb * y;
+
+        // P = P - K.(H.P)
+        double Pa = mPa - Ka * mPa;
+        double Pb = mPb - Ka * mPb;
+        double Pc = mPc - Kb * mPa;
+        double Pd = mPd - Kb * mPb;
+
+        mPa = Pa;
+        mPb = Pb;
+        mPc = Pc;
+        mPd = Pd;
+    }
+
+    /**
+     * Predict state.
+     *
+     * @param acceleration Should be 0 unless there's some sort of control input (a gas pedal, for instance).
+     */
+    public void predict(double acceleration) {
+
+        // x = F.x + G.u
+        mXa = mXa + mXb * mt + acceleration * mt2d2;
+        mXb = mXb + acceleration * mt;
+
+        // P = F.P.F' + Q
+        double Pdt = mPd * mt;
+        double FPFtb = mPb + Pdt;
+        double FPFta = mPa + mt * (mPc + FPFtb);
+        double FPFtc = mPc + Pdt;
+        double FPFtd = mPd;
+
+        mPa = FPFta + mQa;
+        mPb = FPFtb + mQb;
+        mPc = FPFtc + mQc;
+        mPd = FPFtd + mQd;
+    }
+
+    /**
+     * @return Estimated position.
+     */
+    public double getPosition() { return mXa; }
+
+    /**
+     * @return Estimated velocity.
+     */
+    public double getVelocity() { return mXb; }
+
+    /**
+     * @return Accuracy
+     */
+    public double getAccuracy() { return Math.sqrt(mPd / mt2); }
+}

--- a/PocketMaps/app/src/main/res/layout/app_settings.xml
+++ b/PocketMaps/app/src/main/res/layout/app_settings.xml
@@ -374,4 +374,32 @@
             android:checked="true"/>
     </LinearLayout>
 
+    <!-- Smoothen movement (Kalman Filter) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="60dp"
+        android:gravity="right|center_vertical"
+        android:orientation="horizontal"
+        android:paddingBottom="5dp"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="5dp">
+
+        <TextView
+            android:id="@+id/txt_smooth"
+            android:layout_width="120dp"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:text="Smoothen movement"
+            android:textSize="14sp"/>
+
+        <CheckBox
+            android:id="@+id/app_settings_smooth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="28dp"
+            android:checked="false"/>
+    </LinearLayout>
+
 </LinearLayout>

--- a/PocketMaps/app/src/main/res/layout/content_about.xml
+++ b/PocketMaps/app/src/main/res/layout/content_about.xml
@@ -53,7 +53,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/text_margin"
             android:autoLink="web"
-            android:text="Uses open source API\n\n    GraphHopper\n    https://github.com/graphhopper/graphhopper\n\n    mapsforge vtm\n    https://github.com/mapsforge/vtm\n\n    Parts of osmdroid\n    https://github.com/osmdroid/osmdroid\n\n    jjoe64 graphview\n    http://www.android-graphview.org/\n\n    androidsvg\n    https://bigbadaboom.github.io/androidsvg/\n\n    slf4j\n    https://www.slf4j.org/\n\n    okhttp\n    https://github.com/square/okhttp"/>
+            android:text="Uses open source API\n\n    GraphHopper\n    https://github.com/graphhopper/graphhopper\n\n    mapsforge vtm\n    https://github.com/mapsforge/vtm\n\n    Parts of osmdroid\n    https://github.com/osmdroid/osmdroid\n\n    jjoe64 graphview\n    http://www.android-graphview.org/\n\n    androidsvg\n    https://bigbadaboom.github.io/androidsvg/\n\n    slf4j\n    https://www.slf4j.org/\n\n    okhttp\n    https://github.com/square/okhttp\n\n    Modified version of KalmanLocationManager\n    https://github.com/villoren/KalmanLocationManager"/>
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Added the use of [com.villoren.android.kalmanlocationmanager](https://github.com/villoren/KalmanLocationManager) to provide a smoother movement of the location marker.

The code of the kalman filter has been imported directly into the source code, not as a dependency since that was not easily available, and some changes was needed to make it integrate better with pocketmaps.

The default is still to use the current 3 second update, but the new feature can be enabled in the settings.

It is not perfect, but I think it improves the current situation a lot.

Fixes #90 
