### PR TITLE
Fix for cleartext HTTP trafic

### DIFF
--- a/PocketMaps/app/src/main/AndroidManifest.xml
+++ b/PocketMaps/app/src/main/AndroidManifest.xml
@@ -24,7 +24,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:logo="@mipmap/ic_launcher"
-        android:theme="@style/MYAppTheme" >
+        android:theme="@style/MYAppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
+        >
         <activity
             android:launchMode="singleTask"
             android:name=".activities.MainActivity"

--- a/PocketMaps/app/src/main/java/org/osmdroid/location/GeocoderNominatim.java
+++ b/PocketMaps/app/src/main/java/org/osmdroid/location/GeocoderNominatim.java
@@ -28,7 +28,7 @@ public class GeocoderNominatim {
 
     final static Logger log = LoggerFactory.getLogger(GeocoderNominatim.class);
 
-    public static final String NOMINATIM_SERVICE_URL = "http://nominatim.openstreetmap.org/";
+    public static final String NOMINATIM_SERVICE_URL = "https://nominatim.openstreetmap.org/";
     public static final String MAPQUEST_SERVICE_URL = "http://open.mapquestapi.com/nominatim/v1/";
 
     protected Locale mLocale;

--- a/PocketMaps/app/src/main/res/xml/network_security_config.xml
+++ b/PocketMaps/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">vsrv15044.customer.xenway.de</domain>
+    </domain-config>
+</network-security-config>

--- a/PocketMaps/app/src/main/res/xml/network_security_config.xml
+++ b/PocketMaps/app/src/main/res/xml/network_security_config.xml
@@ -2,5 +2,6 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">vsrv15044.customer.xenway.de</domain>
+        <domain includeSubdomains="true">nominatim.openstreetmap.org</domain>
     </domain-config>
 </network-security-config>

--- a/PocketMaps/app/src/main/res/xml/network_security_config.xml
+++ b/PocketMaps/app/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,5 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">vsrv15044.customer.xenway.de</domain>
-        <domain includeSubdomains="true">nominatim.openstreetmap.org</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
This is a suggested fix for #123 
From the android-developers' website:
> Note: [...] Starting with Android 9 (API level 28), cleartext support is disabled by default.

More info can be found [here](https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted).

Note that having the `android:networkSecurityConfig` tag in the manifest creates a warning about the minSdk version that can be safely ignored, since previous sdk version do not need this extra.

