### PR TITLE
Add the requested permission to AndroidManifest.xml

### DIFF
--- a/PocketMaps/app/src/main/AndroidManifest.xml
+++ b/PocketMaps/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-feature android:name="android.hardware.location.gps" />
 
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
This permission is requested by the MainActivity, but is always automatically denied, because it is not in the AndroidManifest.xml.