### PR TITLE
Fix the visibility of a floating action button

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActions.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActions.java
@@ -137,7 +137,7 @@ public class MapActions implements NavigatorListener, MapHandlerListener {
         @Override public void onClick(View view)
         {
           NaviEngine.getNaviEngine().setMapUpdatesAllowed(activity.getApplicationContext(), true);
-          naviCenterBtn.setVisibility(View.INVISIBLE);
+          naviCenterBtn.setVisibility(View.GONE);
         }
       };
       return l;

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/map/MapHandler.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/map/MapHandler.java
@@ -535,7 +535,7 @@ public class MapHandler
     }
     else
     {
-      naviCenterBtn.setVisibility(View.INVISIBLE);
+      naviCenterBtn.setVisibility(View.GONE);
     }
   }
 

--- a/PocketMaps/app/src/main/res/layout/map_centerbutton_bar.xml
+++ b/PocketMaps/app/src/main/res/layout/map_centerbutton_bar.xml
@@ -19,7 +19,7 @@
         android:layout_marginRight="@dimen/fab_margin_default"
         android:layout_marginTop="@dimen/fab_margin_default"
         android:src="@drawable/ic_location_searching_white_24dp"
-        android:visibility="invisible"
+        android:visibility="gone"
         />
 
 </LinearLayout>


### PR DESCRIPTION
This floating action button (FAB) (named: map_southbar_navicenter_fab; usage: center map on current position) should become visible when the user moves the map of the navigation view. But the FAB is sometimes clickable and not visible. 