### PR TITLE
Fix the canceling of the deletion of maps or favourites

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MainActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MainActivity.java
@@ -298,6 +298,15 @@ public class MainActivity extends AppCompatActivity implements OnClickMapListene
                                     recView.getAdapter().notifyItemInserted(vhPos);
                                 }
                             });
+
+                        builder1.setOnCancelListener(new DialogInterface.OnCancelListener() {
+
+                            public void onCancel(DialogInterface dialog) {
+                                int vhPos = viewHolder.getAdapterPosition();
+                                recView.getAdapter().notifyItemRemoved(vhPos);
+                                recView.getAdapter().notifyItemInserted(vhPos);
+                            }
+                        });
   
                         AlertDialog alert11 = builder1.create();
                         alert11.show();


### PR DESCRIPTION
When the confirmation for the deletion is canceled, by clicking outside the message and therefore without using a button, than the element is removed from the list, but the space is still reserved. After reloading the list, the element will be visible again. This commit should fix this behavior.