### PR TITLE
Replace custom constants with standard constants

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MainActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MainActivity.java
@@ -60,8 +60,6 @@ import java.util.List;
  * <br/>Created by GuoJunjun <junjunguo.com> on July 04, 2015.
  */
 public class MainActivity extends AppCompatActivity implements OnClickMapListener {
-    public final static int ITEM_TOUCH_HELPER_LEFT = 4;
-    public final static int ITEM_TOUCH_HELPER_RIGHT = 8;
     private MyMapAdapter mapAdapter;
     private boolean changeMap;
     private RecyclerView mapsRV;
@@ -266,7 +264,7 @@ public class MainActivity extends AppCompatActivity implements OnClickMapListene
     public static void addDeleteItemHandler(final Context context, final RecyclerView recView, final OnItemClickListener l) {
         // swipe left or right to remove an item
         ItemTouchHelper.SimpleCallback simpleItemTouchCallback =
-                new ItemTouchHelper.SimpleCallback(0, ITEM_TOUCH_HELPER_LEFT | ITEM_TOUCH_HELPER_RIGHT) {
+                new ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT) {
                     @Override public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder,
                             RecyclerView.ViewHolder target) {
                         return false;


### PR DESCRIPTION
Replace defined constants: ITEM_TOUCH_HELPER_LEFT / ITEM_TOUCH_HELPER_RIGHT with default implementation: ItemTouchHelper.LEFT / ItemTouchHelper.RIGHT. 
This change is not necessary, but it would be a help for people, who start working on this project, because it is confusing that there are custom constants without additionally functionality when there are default ones.