### PR TITLE
Change the spinner background color for a better readability

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActions.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActions.java
@@ -762,6 +762,7 @@ public class MapActions implements NavigatorListener, MapHandlerListener {
     
     private void initSpinner() {
       Spinner spinner = (Spinner) activity.findViewById(R.id.nav_instruction_list_travel_mode_sp);
+      spinner.setPopupBackgroundResource(R.color.my_primary_light);
 
       ArrayList<SportCategory> spinnerList = new ArrayList<>();
       spinnerList.add(new SportCategory("walk", R.drawable.ic_directions_walk_orange_24dp, Calorie.Type.Run));


### PR DESCRIPTION
The spinner is located at the view that shows the list of the navigation instructions. The default background color and the color of the text make it difficult to read. The solution to this is to change the background color.