### PR TITLE
Fix for the first message of the navigation voice

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MapActivity.java
@@ -99,6 +99,7 @@ public class MapActivity extends Activity implements LocationListener {
         ensureLastLocationInit();
         updateCurrentLocation(null);
         mapAlive = true;
+        NaviEngine.getNaviEngine().naviVoiceInit(this, false);
     }
     
     public void ensureLocationListener(boolean showMsgEverytime)


### PR DESCRIPTION
The auditory output of the first navigation instruction is sometimes not given. This commit should fix this.