### PR TITLE
Fix the bug that occurs when the app is closed and fast restarted

### DIFF
--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MainActivity.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/activities/MainActivity.java
@@ -30,6 +30,7 @@ import android.widget.Toast;
 import com.junjunguo.pocketmaps.R;
 import com.junjunguo.pocketmaps.downloader.MapDownloadUnzip;
 import com.junjunguo.pocketmaps.downloader.MapDownloadUnzip.StatusUpdate;
+import com.junjunguo.pocketmaps.map.Navigator;
 import com.junjunguo.pocketmaps.model.MyMap;
 import com.junjunguo.pocketmaps.model.MyMap.DlStatus;
 import com.junjunguo.pocketmaps.model.MyMap.MapFileType;
@@ -143,13 +144,28 @@ public class MainActivity extends AppCompatActivity implements OnClickMapListene
           changeMap = true;
         }
         // start map activity if load succeed
-        if (loadSuccess)
-        {
-            if (MapActivity.isMapAlive()) { startMapActivity(); } // Continue map
-            else if (!changeMap) { startMapActivity(); }
+        if (loadSuccess) {
+            if (MapActivity.isMapAlive()) {
+                startMapActivity(); // Continue map
+            }
+            else if (!changeMap) {
+                startMapActivity();
+            }
+            else {
+                resetBackgroundClasses();
+            }
+        }
+        else{
+            resetBackgroundClasses();
         }
         activityLoaded = true;
         return true;
+    }
+
+    private void resetBackgroundClasses(){
+        MapHandler.reset();
+        NaviEngine.reset();
+        Navigator.reset();
     }
 
     /**

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/map/Navigator.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/map/Navigator.java
@@ -43,6 +43,10 @@ public class Navigator {
         this.listeners = new ArrayList<>();
     }
 
+    public static void reset(){
+        navigator = new Navigator();
+    }
+
     /**
      * @return Navigator object
      */

--- a/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/navigator/NaviEngine.java
+++ b/PocketMaps/app/src/main/java/com/junjunguo/pocketmaps/navigator/NaviEngine.java
@@ -70,6 +70,10 @@ public class NaviEngine
     if (instance == null) { instance = new NaviEngine(); }
     return instance;
   }
+
+  public static void reset(){
+    instance = new NaviEngine();
+  }
   
   public boolean isNavigating()
   {


### PR DESCRIPTION
How to reproduce the bug:
-Fist of all a navigation is started. That means the user is on the view with the current instruction and the map (with tilt).
-Then the user has to do the following steps really fast:
       -Close the app
       -Open PocketMaps
       -Open the same map
-If the user was fast enough the map should be centered on the current location, with the same tilt as the navigation view had.
-If the user tries to start a navigation now, than the app crashes.

The problem is that the classes who control the navigation and the map did not close and reopen properly.
This commit should fix this problem.